### PR TITLE
Fixed mapcar error by using cl-lib provided in Emacs after ver 24.3

### DIFF
--- a/theme-magic.el
+++ b/theme-magic.el
@@ -47,6 +47,7 @@
 (require 'font-lock)
 (require 'ansi-color)
 (require 'seq)
+(require 'cl-lib)
 
 
 (defvar theme-magic--theming-functions
@@ -458,7 +459,7 @@ handling."
   (message "Applying colors: %s"
            ;; Number the colors to make it clearer for the user which color is
            ;; being applied where.
-           (mapcar* #'cons
+           (cl-mapcar #'cons
                     (number-sequence 0 (length colors))
                     colors))
   (if (zerop (theme-magic--call-pywal-process colors))


### PR DESCRIPTION
Fixed the error in #12 using cl-lib. If adding a dependency is to be avoided, you could write a mapcar* function that does the job instead.